### PR TITLE
Missing Doc Fails Maven Build Against Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,6 +288,15 @@
 					</execution>
 				</executions>
 			</plugin>
+			
+			<plugin>
+			    <groupId>org.apache.maven.plugins</groupId>
+			    <artifactId>maven-javadoc-plugin</artifactId>
+			    <configuration>
+			      <additionalparam>-Xdoclint:none</additionalparam>
+			    </configuration>
+			  </plugin>
+			
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
This fix disable Java-doc strict checking during compilation in Java 8. Could be consider a temporary fix for the issue until the errors are resolved.